### PR TITLE
remove final resource network stanza

### DIFF
--- a/nomad_jobs/hashicups/hashicups-multiregion.nomad
+++ b/nomad_jobs/hashicups/hashicups-multiregion.nomad
@@ -117,7 +117,7 @@ job "hashicups" {
   } # end postgres group
 
   # Products API component that interfaces with the Postgres database
-  group "products-api" {
+  group "product-api" {
     count = 1
 
     network {
@@ -133,7 +133,7 @@ job "hashicups" {
       mode     = "delay"
     }
 
-    task "products-api" {
+    task "product-api" {
       driver = "docker"
 
       # Creation of the template file defining how the API will access the database
@@ -190,9 +190,9 @@ EOF
 
       # Service definition to be sent to Consul with corresponding health check
       service {
-        name = "products-api-server"
+        name = "product-api-server"
         port = "http_port"
-        tags = ["products-api"]
+        tags = ["product-api"]
         check {
           type     = "http"
           path     = "/health"
@@ -200,9 +200,203 @@ EOF
           timeout  = "2s"
         }
       }
-    } # end products-api task
-  } # end products-api group
+    } # end product-api task
+  } # end product-api group
 
+  # Public API component
+  group "public-api" {
+    count = 1
+
+    network {
+      port "pub_api" {
+        static = 9080
+      }
+    }
+
+    restart {
+      attempts = 10
+      interval = "5m"
+      delay    = "25s"
+      mode     = "delay"
+    }
+
+    # Define update strategy for the Payments API
+    update {
+      canary  = 1
+    }
+
+    task "public-api" {
+      driver = "docker"
+
+      # Task relevant environment variables necessary
+      env {
+        BIND_ADDRESS = ":9080"
+        PRODUCT_API_URI = "http://product-api-server.service.consul:9090"
+        PAYMENT_API_URI = "http://payments-api-server.service.consul:8080"
+      }
+
+      # Public-api Docker image location and configuration
+      config {
+        image = "hashicorpdemoapp/public-api:v0.0.4"
+        dns_servers = ["172.17.0.1"]
+        ports = ["pub_api"]
+      }
+
+      # Host machine resources required
+      resources {
+        cpu    = 100
+        memory = 256
+      }
+
+      scaling "cpu" {
+        policy {
+          cooldown            = "1m"
+          evaluation_interval = "1m"
+          check "95pct" {
+            strategy "app-sizing-percentile" {
+              percentile = "95"
+            }
+          }
+        }
+      } # End scaling cpu
+
+      scaling "mem" {
+        policy {
+          cooldown            = "1m"
+          evaluation_interval = "1m"
+          check "max" {
+            strategy "app-sizing-max" {}
+          }
+        }
+      } # End scaling mem
+
+      # Service definition to be sent to Consul with corresponding health check
+      service {
+        name = "public-api-server"
+        port = "pub_api"
+        tags = ["public-api"]
+        check {
+          type     = "tcp"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
+
+  # Frontend component providing user access to the application
+  group "frontend" {
+    count = 0
+
+    network {
+      port "http" {
+        static = 80
+      }
+    }
+
+    restart {
+      attempts = 10
+      interval = "5m"
+      delay    = "15s"
+      mode     = "delay"
+    }
+
+    task "server" {
+      driver = "docker"
+
+      # Task relevant environment variables necessary
+      env {
+        PORT    = "${NOMAD_PORT_http}"
+        NODE_IP = "${NOMAD_IP_http}"
+      }
+
+      # Frontend Docker image location and configuration
+      config {
+        image = "hashicorpdemoapp/frontend:v0.0.4"
+        dns_servers = ["172.17.0.1"]
+        volumes = [
+          "local:/etc/nginx/conf.d",
+        ]
+        ports = ["http"]
+      }
+
+      # Creation of the NGINX configuration file
+      template {
+        data = <<EOF
+resolver 172.17.0.1 valid=1s;
+server {
+    listen       80;
+    server_name  localhost;
+    set $upstream_endpoint public-api-server.service.consul;
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+    # Proxy pass the api location to save CORS
+    # Use location exposed by Consul connect
+    location /api {
+        proxy_pass http://$upstream_endpoint:9080;
+        # Need the next 4 lines. Else browser might think X-site.
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+    }
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}
+EOF
+        destination   = "local/default.conf"
+        change_mode   = "signal"
+        change_signal = "SIGHUP"
+      }
+
+      # Host machine resources required
+      resources {
+        cpu = 100
+        memory = 256
+      }
+
+      scaling "cpu" {
+        policy {
+          cooldown            = "1m"
+          evaluation_interval = "1m"
+          check "95pct" {
+            strategy "app-sizing-percentile" {
+              percentile = "95"
+            }
+          }
+        }
+      } # End scaling cpu
+
+      scaling "mem" {
+        policy {
+          cooldown            = "1m"
+          evaluation_interval = "1m"
+          check "max" {
+            strategy "app-sizing-max" {}
+          }
+        }
+      } # End scaling mem
+
+      # Service definition to be sent to Consul with corresponding health check
+      service {
+        name = "frontend"
+        port = "http"
+
+        tags = ["frontend"]
+
+        check {
+          type     = "http"
+          path     = "/"
+          interval = "2s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
 
   # Payment API component handles payments
   group "payments-api" {
@@ -319,206 +513,4 @@ EOF
 
     } # end payments-api task
   } # end payments-api group
-
-  # Public API component
-  group "public-api" {
-    count = 1
-
-    network {
-      port "pub_api" {
-        static = 9080
-      }
-    }
-
-    restart {
-      attempts = 10
-      interval = "5m"
-      delay    = "25s"
-      mode     = "delay"
-    }
-
-    # Define update strategy for the Payments API
-    update {
-      canary  = 1
-    }
-
-    task "public-api" {
-      driver = "docker"
-
-      # Task relevant environment variables necessary
-      env {
-        BIND_ADDRESS = ":9080"
-        PRODUCT_API_URI = "http://products-api-server.service.consul:9090"
-        PAYMENT_API_URI = "http://payments-api-server.service.consul:8080"
-      }
-
-      # Public-api Docker image location and configuration
-      config {
-        image = "hashicorpdemoapp/public-api:v0.0.4"
-        dns_servers = ["172.17.0.1"]
-        ports = ["pub_api"]
-      }
-
-      # Host machine resources required
-      resources {
-        cpu    = 100
-        memory = 256
-      }
-
-      scaling "cpu" {
-        policy {
-          cooldown            = "1m"
-          evaluation_interval = "1m"
-          check "95pct" {
-            strategy "app-sizing-percentile" {
-              percentile = "95"
-            }
-          }
-        }
-      } # End scaling cpu
-
-      scaling "mem" {
-        policy {
-          cooldown            = "1m"
-          evaluation_interval = "1m"
-          check "max" {
-            strategy "app-sizing-max" {}
-          }
-        }
-      } # End scaling mem
-
-      # Service definition to be sent to Consul with corresponding health check
-      service {
-        name = "public-api-server"
-        port = "pub_api"
-        tags = ["public-api"]
-        check {
-          type     = "tcp"
-          interval = "10s"
-          timeout  = "2s"
-        }
-      }
-    }
-  }
-
-  # Frontend component providing user access to the application
-
-  group "frontend" {
-    count = 0
-
-    network {
-      port "http" {
-        static = 80
-      }
-    }
-
-    restart {
-      attempts = 10
-      interval = "5m"
-      delay    = "15s"
-      mode     = "delay"
-    }
-
-    task "server" {
-      driver = "docker"
-
-      # Task relevant environment variables necessary
-      env {
-        PORT    = "${NOMAD_PORT_http}"
-        NODE_IP = "${NOMAD_IP_http}"
-      }
-
-      # Frontend Docker image location and configuration
-      config {
-        image = "hashicorpdemoapp/frontend:v0.0.4"
-        dns_servers = ["172.17.0.1"]
-        volumes = [
-          "local:/etc/nginx/conf.d",
-        ]
-        ports = ["http"]
-      }
-
-      # Creation of the NGINX configuration file
-      template {
-        data = <<EOF
-resolver 172.17.0.1 valid=1s;
-server {
-    listen       80;
-    server_name  localhost;
-    set $upstream_endpoint public-api-server.service.consul;
-    location / {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-    }
-    # Proxy pass the api location to save CORS
-    # Use location exposed by Consul connect
-    location /api {
-        proxy_pass http://$upstream_endpoint:9080;
-        # Need the next 4 lines. Else browser might think X-site.
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-        proxy_set_header Host $host;
-    }
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /usr/share/nginx/html;
-    }
-}
-EOF
-        destination   = "local/default.conf"
-        change_mode   = "signal"
-        change_signal = "SIGHUP"
-      }
-
-      # Host machine resources required
-      resources {
-        cpu = 100
-        memory = 256
-        network {
-          mbits = 10
-          port  "http"{
-            static = 80
-          }
-        }
-      }
-
-      scaling "cpu" {
-        policy {
-          cooldown            = "1m"
-          evaluation_interval = "1m"
-          check "95pct" {
-            strategy "app-sizing-percentile" {
-              percentile = "95"
-            }
-          }
-        }
-      } # End scaling cpu
-
-      scaling "mem" {
-        policy {
-          cooldown            = "1m"
-          evaluation_interval = "1m"
-          check "max" {
-            strategy "app-sizing-max" {}
-          }
-        }
-      } # End scaling mem
-
-      # Service definition to be sent to Consul with corresponding health check
-      service {
-        name = "frontend"
-        port = "http"
-
-        tags = ["frontend"]
-
-        check {
-          type     = "http"
-          path     = "/"
-          interval = "2s"
-          timeout  = "2s"
-        }
-      }
-    }
-  }
 }

--- a/nomad_jobs/hashicups/hashicups.nomad
+++ b/nomad_jobs/hashicups/hashicups.nomad
@@ -104,7 +104,7 @@ job "hashicups" {
   } # end postgres group
 
   # Products API component that interfaces with the Postgres database
-  group "products-api" {
+  group "product-api" {
     count = 1
 
     network {
@@ -120,7 +120,7 @@ job "hashicups" {
       mode     = "delay"
     }
 
-    task "products-api" {
+    task "product-api" {
       driver = "docker"
 
       # Creation of the template file defining how the API will access the database
@@ -177,9 +177,9 @@ EOF
 
       # Service definition to be sent to Consul with corresponding health check
       service {
-        name = "products-api-server"
+        name = "product-api-server"
         port = "http_port"
-        tags = ["products-api"]
+        tags = ["product-api"]
         check {
           type     = "http"
           path     = "/health"
@@ -187,8 +187,8 @@ EOF
           timeout  = "2s"
         }
       }
-    } # end products-api task
-  } # end products-api group
+    } # end product-api task
+  } # end product-api group
 
   # Public API component
   group "public-api" {
@@ -213,7 +213,7 @@ EOF
       # Task relevant environment variables necessary
       env {
         BIND_ADDRESS = ":9080"
-        PRODUCT_API_URI = "http://products-api-server.service.consul:9090"
+        PRODUCT_API_URI = "http://product-api-server.service.consul:9090"
       }
 
       # Public-api Docker image location and configuration
@@ -267,7 +267,6 @@ EOF
   }
 
   # Frontend component providing user access to the application
-
   group "frontend" {
     count = 3
 


### PR DESCRIPTION
removed final resource network stanza that I had neglected to remove from the frontend task.
Also moved payments-api task group to botton of hashicups-custom.nomad and hashicups-multiregion.nomad files to make it easier to compare the 3 hashicups Nomad job specs.
Also changed "products-api" top "product-api" in all 3 jobs.