### PR TITLE
revert back to payments api 0.0.11

### DIFF
--- a/nomad_jobs/hashicups/hashicups-custom.nomad
+++ b/nomad_jobs/hashicups/hashicups-custom.nomad
@@ -450,24 +450,21 @@ spring:
       host: server-a-1
       port: 8200
       scheme: http
+      kv:
+        enabled: false
+      generic:
+        enabled: false
 EOF
       }
 
-      # Task relevant environment variables necessary
-      env {
-        SPRING_CONFIG_LOCATION = "file:/local/"
-        SPRING_CLOUD_BOOTSTRAP_LOCATION = "file:/local/"
-      }
-
       # Product-api Docker image location and configuration
-
-     config {
-        jar_path    = "local/spring-boot-payments-0.0.5.jar"
+      config {
+        jar_path    = "local/spring-boot-payments-0.0.11.jar"
         jvm_options = ["-Xmx1024m", "-Xms256m"]
       }
 
       artifact {
-         source = "https://github.com/hashicorp-demoapp/payments/releases/download/v0.0.5/spring-boot-payments-0.0.5.jar"
+         source = "https://github.com/hashicorp-demoapp/payments/releases/download/v0.0.11/spring-boot-payments-0.0.11.jar"
       }
 
       # Host machine resources required

--- a/nomad_jobs/hashicups/hashicups-multiregion.nomad
+++ b/nomad_jobs/hashicups/hashicups-multiregion.nomad
@@ -463,24 +463,42 @@ spring:
       host: server-a-1
       port: 8200
       scheme: http
+      kv:
+        enabled: false
+      generic:
+        enabled: false
 EOF
       }
 
-      # Task relevant environment variables necessary
-      env {
-        SPRING_CONFIG_LOCATION = "file:/local/"
-        SPRING_CLOUD_BOOTSTRAP_LOCATION = "file:/local/"
+      # Creation of the template file defining how to connect to vault
+      template {
+        destination   = "local/bootstrap.yml"
+        data = <<EOF
+spring:
+  cloud:
+    vault:
+      enabled: true
+      fail-fast: true
+      authentication: TOKEN
+      token: REPLACETOKEN
+      host: server-a-1
+      port: 8200
+      scheme: http
+      kv:
+        enabled: false
+      generic:
+        enabled: false
+EOF
       }
 
       # Product-api Docker image location and configuration
-
-     config {
-        jar_path    = "local/spring-boot-payments-0.0.5.jar"
+      config {
+        jar_path    = "local/spring-boot-payments-0.0.11.jar"
         jvm_options = ["-Xmx1024m", "-Xms256m"]
       }
 
       artifact {
-         source = "https://github.com/hashicorp-demoapp/payments/releases/download/v0.0.5/spring-boot-payments-0.0.5.jar"
+         source = "https://github.com/hashicorp-demoapp/payments/releases/download/v0.0.11/spring-boot-payments-0.0.11.jar"
       }
 
       # Host machine resources required

--- a/nomad_jobs/hashicups/temp.nomad
+++ b/nomad_jobs/hashicups/temp.nomad
@@ -262,24 +262,68 @@ spring:
       host: server-a-1
       port: 8200
       scheme: http
+      kv:
+        enabled: false
+      generic:
+        enabled: false
 EOF
       }
 
-      # Task relevant environment variables necessary
-      env {
-        SPRING_CONFIG_LOCATION = "file:/local/"
-        SPRING_CLOUD_BOOTSTRAP_LOCATION = "file:/local/"
+      template {
+        destination   = "local/application.yaml"
+        data = <<EOF
+spring:
+  application:
+    name: payments-api
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driverClassName: org.h2.Driver
+    username: sa
+    password: password
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true
+management:
+  endpoint:
+    health:
+      show-details: always
+EOF
+      }
+
+      # Creation of the template file defining how to connect to vault
+      template {
+        destination   = "local/bootstrap.yml"
+        data = <<EOF
+spring:
+  cloud:
+    vault:
+      enabled: true
+      fail-fast: true
+      authentication: TOKEN
+      token: REPLACETOKEN
+      host: server-a-1
+      port: 8200
+      scheme: http
+      kv:
+        enabled: false
+      generic:
+        enabled: false
+EOF
       }
 
       # Product-api Docker image location and configuration
-
-     config {
-        jar_path    = "local/spring-boot-payments-0.0.5.jar"
+      config {
+        jar_path    = "local/spring-boot-payments-0.0.11.jar"
         jvm_options = ["-Xmx1024m", "-Xms256m"]
       }
 
       artifact {
-         source = "https://github.com/hashicorp-demoapp/payments/releases/download/v0.0.5/spring-boot-payments-0.0.5.jar"
+         source = "https://github.com/hashicorp-demoapp/payments/releases/download/v0.0.11/spring-boot-payments-0.0.11.jar"
       }
 
       # Host machine resources required


### PR DESCRIPTION
Lance Larsen helped me figure out how to make payments-api 0.0.11 work.  We had to add template for application.yaml and/or remove the env vars.  We actually did both because having the env vars with 0.0.11 stopped the Nomad UI for showing files or doing exec for the payments-api container.