### PR TITLE
add application.yml template to hashicups jobs

### DIFF
--- a/nomad_jobs/hashicups/hashicups-custom.nomad
+++ b/nomad_jobs/hashicups/hashicups-custom.nomad
@@ -457,6 +457,32 @@ spring:
 EOF
       }
 
+      template {
+        destination   = "local/application.yaml"
+        data = <<EOF
+spring:
+  application:
+    name: payments-api
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driverClassName: org.h2.Driver
+    username: sa
+    password: password
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true
+management:
+  endpoint:
+    health:
+      show-details: always
+EOF
+      }
+
       # Product-api Docker image location and configuration
       config {
         jar_path    = "local/spring-boot-payments-0.0.11.jar"

--- a/nomad_jobs/hashicups/hashicups-multiregion.nomad
+++ b/nomad_jobs/hashicups/hashicups-multiregion.nomad
@@ -470,6 +470,32 @@ spring:
 EOF
       }
 
+      template {
+        destination   = "local/application.yaml"
+        data = <<EOF
+spring:
+  application:
+    name: payments-api
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driverClassName: org.h2.Driver
+    username: sa
+    password: password
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true
+management:
+  endpoint:
+    health:
+      show-details: always
+EOF
+      }
+
       # Creation of the template file defining how to connect to vault
       template {
         destination   = "local/bootstrap.yml"


### PR DESCRIPTION
add the payment-api application.yml template to the hashicups-custom.nomad and hashicups-multiregion.nomad jobs to make it very explicit what properties are being used in the file.