### PR TITLE
remove quotes for VAULT_TOKEN

### DIFF
--- a/ansible/roles/nomad/templates/init.service.j2
+++ b/ansible/roles/nomad/templates/init.service.j2
@@ -11,7 +11,7 @@ Wants=consul.service
 After=consul.service
 
 [Service]
-Environment="VAULT_TOKEN={{ lookup('file', '/tmp/rootKey/{{vault_server}}/rootkey')}}"
+Environment=VAULT_TOKEN={{ lookup('file', '/tmp/rootKey/{{vault_server}}/rootkey')}}
 ExecReload=/bin/kill -HUP $MAINPID
 #ExecStart=/usr/bin/nomad agent -config /etc/nomad.d
 ExecStart=/usr/local/bin/nomad agent -config /etc/nomad.d


### PR DESCRIPTION
In init.service.j2, the quotes for setting VAULT_TOKEN stopped Nomad from starting.
The line now reads:
```
Environment=VAULT_TOKEN={{ lookup('file', '/tmp/rootKey/{{vault_server}}/rootkey')}}
```
which will be translated by Ansible to something like this:
```
Environment=VAULT_TOKEN=s.dsfiohgf89y34jks
```