### PR TITLE
fix symmetricds artifact URL

### DIFF
--- a/nomad_jobs/hashicups/symmetricds.nomad
+++ b/nomad_jobs/hashicups/symmetricds.nomad
@@ -33,7 +33,7 @@ job "postgres-sync-service" {
       delay    = "25s"
       mode     = "delay"
     }
-    
+
     task "setup-db" {
       #Should only be done after sync is initally setup, so will error on first run
 
@@ -96,7 +96,7 @@ EOH
     task "symmetric-test" {
       driver = "raw_exec"
       artifact {
-        source = "https://netactuate.dl.sourceforge.net/project/symmetricds/symmetricds/symmetricds-3.12/symmetric-server-3.12.8.zip"
+        source = "https://sourceforge.net/projects/symmetricds/files/symmetricds/symmetricds-3.12/symmetric-server-3.12.8.zip/download?filename=symmetric-server-3.12.8.zip&archive=zip"
         destination = "local/"
       }
 


### PR DESCRIPTION
The old URL, https://netactuate.dl.sourceforge.net/project/symmetricds/symmetricds/symmetricds-3.12/symmetric-server-3.12.8.zip,  for the artifact for the symmetric-test task of the symmetricds.nomad job spec file was no longer working since the mirror at netactuate seems to have been discontinued.  So, I switched to the primary download at https://sourceforge.net/projects/symmetricds/files/symmetricds/symmetricds-3.12/symmetric-server-3.12.8.zip/download.  However, to make that work with the extra `/download` in the URL, I had to add `?filename=symmetric-server-3.12.8.zip&archive=zip` as documented in https://github.com/hashicorp/go-getter/blob/main/README.md#general-all-protocols.

Note also that while Chrome will redirect from https://sourceforge.net/projects/symmetricds/files/symmetricds/symmetricds-3.12/symmetric-server-3.12.8.zip to https://sourceforge.net/projects/symmetricds/files/symmetricds/symmetricds-3.12/symmetric-server-3.12.8.zip/download, Nomad would not.  So, I had to include `/download` in the URL and therefore had to use the extra go-getter arguments to fix the file name and tell Nomad that the file is an archive.  I tested just using `?filename=symmetric-server-3.12.8.zip`, but that did not work since go-getter decides whether to unarchive based on the URL, not the file name.