### PR TITLE
fix canaries

### DIFF
--- a/nomad_jobs/hashicups/hashicups-custom.nomad
+++ b/nomad_jobs/hashicups/hashicups-custom.nomad
@@ -207,7 +207,7 @@ EOF
       mode     = "delay"
     }
 
-    # Define update strategy for the Payments API
+    # Define update strategy for the Public API
     update {
       canary  = 1
     }
@@ -403,11 +403,6 @@ EOF
       interval = "5m"
       delay    = "25s"
       mode     = "delay"
-    }
-
-  # Define update strategy for the Payments API
-    update {
-      canary  = 1
     }
 
     # Service definition to be sent to Consul with corresponding health check

--- a/nomad_jobs/hashicups/hashicups-multiregion.nomad
+++ b/nomad_jobs/hashicups/hashicups-multiregion.nomad
@@ -220,7 +220,7 @@ EOF
       mode     = "delay"
     }
 
-    # Define update strategy for the Payments API
+    # Define update strategy for the Public API
     update {
       canary  = 1
     }
@@ -416,11 +416,6 @@ EOF
       interval = "5m"
       delay    = "25s"
       mode     = "delay"
-    }
-
-    # Define update strategy for the Payments API
-    update {
-      canary  = 1
     }
 
     # Service definition to be sent to Consul with corresponding health check


### PR DESCRIPTION
Only the public-api task group should be a canary.  The new payments-api service should not be.